### PR TITLE
Downgrade Go version from 1.25.1 to 1.24 for Hugo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tats-u/goldmark-cjk-friendly
 
-go 1.25.1
+go 1.24
 
 require github.com/yuin/goldmark v1.7.13


### PR DESCRIPTION
This PR downgrades the Go version from 1.25.1 to 1.24.

This change is needed as my PR (https://github.com/gohugoio/hugo/pull/14115) for adding [goldmark-cjk-friendly](https://github.com/tats-u/goldmark-cjk-friendly) to Hugo currently fails (https://github.com/gohugoio/hugo/actions/runs/19108543733/job/54686869533?pr=14115) because Hugo CI test worfklows expect to work on Go 1.24 and 1.25: https://github.com/gohugoio/hugo/blob/91eac9e573da41d68d061b453738d3e86420f3d7/.github/workflows/test.yml#L19